### PR TITLE
boot() method collisions fix

### DIFF
--- a/src/Data/Models/Uuidable.php
+++ b/src/Data/Models/Uuidable.php
@@ -14,9 +14,8 @@ trait Uuidable
      *
      * @return void
      */
-    protected static function boot()
+    protected static function bootUuidable()
     {
-        parent::boot();
         /**
          * Attach to the 'creating' Model Event to provide a UUID
          * for the `id` field (provided by $model->getKeyName()).


### PR DESCRIPTION
`Trait method boot has not been applied, because there are collisions with other trait methods`